### PR TITLE
Add Processors support

### DIFF
--- a/grammar.ohm
+++ b/grammar.ohm
@@ -1,7 +1,7 @@
 Pie {
     pieFile = (comment | topLevel | blankLine)*
 
-    topLevel = environmentSpec | environmentalDef | requestDef
+    topLevel = environmentSpec | environmentalDef | requestDef | processorDef
 
     environmentalDef = headerDef | variableDef
 
@@ -20,21 +20,33 @@ Pie {
     inEnvDef (Indented Header or variable)
     = eos indent environmentalDef
 
+    processorDef
+    = "PROCESSOR" space+ identifier space+ "```" processorStatement* "```"
+
+    processorStatement
+    = ~"```" any
+
+    processorValue
+    = identifier | variableValue
+
+    processorPipe (Processor Pipe)
+    = space+ "|" space+ identifier
+
     requestDef (Request)
-    = requestMethod requestPath #eos requestHeaders? requestBody?
+    = requestMethod requestPath processorPipe? #eos requestHeaders? requestBody?
 
     requestMethod
     = methodName space+
 
     // TODO allow trailing comments?
     requestPath
-    = value
+    = (~eol ~space any)+
 
     requestHeaders
     = (headerDef eos)+
 
     methodName (HTTP Request Method)
-    = upper+
+    = ~"PROCESSOR" upper+
 
     requestBody (Any series of non-blank lines)
     = (~emptyLine value eos)+

--- a/package-lock.json
+++ b/package-lock.json
@@ -1445,6 +1445,11 @@
         "extsprintf": "^1.2.0"
       }
     },
+    "vm2": {
+      "version": "3.8.4",
+      "resolved": "https://registry.npmjs.org/vm2/-/vm2-3.8.4.tgz",
+      "integrity": "sha512-5HThl+RBO/pwE9SF0kM4nLrpq5vXHBNk4BMX27xztvl0j1RsZ4/PMVJAu9rM9yfOtTo5KroL7XNX3031ExleSw=="
+    },
     "which": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "ohm-js": "^0.14.0",
     "request": "^2.88.0",
     "request-promise-native": "^1.0.7",
+    "vm2": "^3.8.4",
     "yargs": "^14.0.0"
   },
   "devDependencies": {

--- a/src/ast.ts
+++ b/src/ast.ts
@@ -36,9 +36,17 @@ export class RequestDef {
     constructor(
         public readonly method: string,
         public readonly path: string,
+        public readonly processorName: string | null,
         public readonly body: string | null,
         public readonly headers: Var[],
         public readonly interval: IInterval,
+    ) {}
+}
+
+export class ProcessorDef {
+    constructor(
+        public readonly name: string,
+        public readonly source: string,
     ) {}
 }
 

--- a/src/cli/exec.ts
+++ b/src/cli/exec.ts
@@ -10,6 +10,7 @@ import { clearScreen, colorize, println, readFileValue, startSpinner } from "./u
 export interface IExecuteFlags {
     color: boolean;
     headers: boolean;
+    oob: boolean;
     raw: boolean;
     spinner: boolean;
     status: boolean;
@@ -58,8 +59,17 @@ export async function executeOnContents(
     const engine = await Engine.fromString(contents.toString());
 
     try {
-        const request = engine.buildRequestAt(line);
-        const response = await engine.performRequest(request);
+        const context = engine.findRequestContextAt(line);
+        const request = engine.buildRequest(context);
+        const {
+            newVars,
+            response,
+        } = await engine.processRequest(context, request);
+
+        if (opts.oob) {
+            // tslint:disable-next-line no-console
+            console.error("pie:oob", JSON.stringify([ "new-vars", newVars ]));
+        }
 
         stopSpinner();
         trigger(lifecycle, "onResponseReceived");

--- a/src/cli/flags.ts
+++ b/src/cli/flags.ts
@@ -4,6 +4,7 @@ import { IExecuteFlags } from "./exec";
 export const executeFlagDefaults: IExecuteFlags = {
     color: true,
     headers: true,
+    oob: false,
     raw: false,
     spinner: false,
     status: true,
@@ -19,6 +20,10 @@ export function withExecuteFlags<T>(
     }).option("color", {
         default: executeFlagDefaults.color,
         desc: "Colorize JSON responses",
+        type: "boolean",
+    }).option("oob", {
+        default: executeFlagDefaults.oob,
+        desc: "Output out-of-band messages to stderr",
         type: "boolean",
     }).option("raw", {
         default: executeFlagDefaults.raw,

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -57,7 +57,7 @@ export class Engine {
         let newVars: any | undefined;
         if (context.processor) {
             const processor = new ResponseProcessor(context.processor);
-            newVars = processor.process(context, response);
+            newVars = await processor.process(context, response);
         }
 
         return {

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -8,6 +8,7 @@ import { PieFile } from "./ast";
 import { RequestContext } from "./context";
 import { ParseError } from "./parse-error";
 import { Parser } from "./parser";
+import { ResponseProcessor } from "./processor";
 
 export interface IResponse {
     body: any;
@@ -37,6 +38,32 @@ export class Engine {
     ): Promise<IResponse> {
         const req = this.buildRequestAt(lineNr);
         return this.performRequest(req);
+    }
+
+    public async processRequestAt(
+        lineNr: number,
+    ) {
+        const context = this.findRequestContextAt(lineNr);
+        const req = this.buildRequest(context);
+        return this.processRequest(context, req);
+    }
+
+    public async processRequest(
+        context: RequestContext,
+        req: request.OptionsWithUrl,
+    ) {
+        const response = await this.performRequest(req);
+
+        let newVars: any | undefined;
+        if (context.processor) {
+            const processor = new ResponseProcessor(context.processor);
+            newVars = processor.process(context, response);
+        }
+
+        return {
+            newVars,
+            response,
+        };
     }
 
     public async performRequest(
@@ -74,11 +101,27 @@ export class Engine {
         };
     }
 
-    public buildRequestAt(
+    public findRequestContextAt(
         lineNr: number,
     ) {
         const context = RequestContext.create(this.file, lineNr);
+        if (!context.hasRequest) {
+            // error
+            throw new Error("No request found");
+        }
+        return context;
+    }
 
+    public buildRequestAt(
+        lineNr: number,
+    ) {
+        const context = this.findRequestContextAt(lineNr);
+        return this.buildRequest(context);
+    }
+
+    public buildRequest(
+        context: RequestContext,
+    ) {
         const headers: {[key: string]: string} = Object.assign({}, defaultHeaders);
         for (const [header, headerValue] of Object.entries(context.headers)) {
             if (header === "host") continue;

--- a/src/processor.ts
+++ b/src/processor.ts
@@ -1,0 +1,35 @@
+import { VM } from "vm2";
+
+import { ProcessorDef } from "./ast";
+import { RequestContext } from "./context";
+import { IResponse } from "./engine";
+
+export class ResponseProcessor {
+    constructor(
+        private readonly def: ProcessorDef,
+    ) {}
+
+    public async process(context: RequestContext, response: IResponse) {
+        const vars: {[name: string]: any} = {};
+        for (const varName of Object.keys(context.vars)) {
+            vars[varName] = context.vars[varName];
+        }
+
+        const sandbox: any = {
+            headers: response.headers,
+            status: response.statusCode,
+            vars,
+        };
+
+        if (response.bodyJson) {
+            sandbox.json = response.bodyJson;
+        }
+
+        const vm = new VM({
+            sandbox,
+        });
+        vm.run(this.def.source);
+
+        return sandbox.vars;
+    }
+}

--- a/src/processor.ts
+++ b/src/processor.ts
@@ -12,7 +12,7 @@ export class ResponseProcessor {
     public async process(context: RequestContext, response: IResponse) {
         const vars: {[name: string]: any} = {};
         for (const varName of Object.keys(context.vars)) {
-            vars[varName] = context.vars[varName];
+            vars[varName] = context.vars[varName].value;
         }
 
         const sandbox: any = {
@@ -30,6 +30,14 @@ export class ResponseProcessor {
         });
         vm.run(this.def.source);
 
-        return sandbox.vars;
+        const result: typeof vars = {};
+        for (const varName of Object.keys(sandbox.vars)) {
+            const contextVar = context.vars[varName];
+            if (!contextVar || sandbox.vars[varName] !== contextVar.value) {
+                result[varName] = sandbox.vars[varName];
+            }
+        }
+
+        return result;
     }
 }

--- a/test/parser-test.ts
+++ b/test/parser-test.ts
@@ -218,4 +218,21 @@ $cargo = "\\"totally legal\\" \\\\ awesome goods"
         e.should.have.property("message")
             .that.matches(/Expected .* string literal/);
     });
+
+    it("handles processors", async () => {
+       const file = await new Parser().parse(`
+GET /auth | authenticate
+
+PROCESSOR authenticate \`\`\`
+state.auth = json.rank.captain;
+\`\`\`
+       `);
+
+       file.entries[0].should.have.property("processorName").that.equals("authenticate");
+
+       file.entries[1].should.have.property("name").that.equals("authenticate");
+       file.entries[1].should.have.property("source").that.equals(`
+           state.auth = json.rank.captain;
+       `.trim());
+    });
 });

--- a/test/processor-test.ts
+++ b/test/processor-test.ts
@@ -1,0 +1,38 @@
+import * as chai from "chai";
+
+import { Engine } from "../src/engine";
+import { ResponseProcessor } from "../src/processor";
+
+chai.should();
+
+describe("Processor", () => {
+    it("returns updated vars", async () => {
+        const engine = await Engine.fromString(`
+GET /cargo | stash
+
+PROCESSOR stash \`\`\`
+vars.stashed = json.cargo[0];
+\`\`\`
+        `.trim());
+
+        const context = engine.findRequestContextAt(1);
+        if (!context.processor) {
+            throw new Error("missing processor");
+        }
+
+        const processor = new ResponseProcessor(context.processor);
+        const result = await processor.process(context, {
+            body: "",
+            bodyJson: {
+                cargo: [
+                    "bobble-headed-geisha-dolls",
+                ],
+            },
+            headers: {},
+            httpVersion: "2",
+            statusCode: 200,
+            statusMessage: "OK",
+        });
+        result.stashed.should.equal("bobble-headed-geisha-dolls");
+    });
+});


### PR DESCRIPTION
A `PROCESSOR` is a chunk of javascript code that you can pipe the result of a request into. It has various state available (such as the `vars` variable containing a map of vars in scope, the `json` variable containing the parsed JSON response, if any) and can modify that state by, for example, updating vars.

This PR starts with a simple, naive approach of emitting changed vars in an "out of band" log via the `stderr` channel. Events are newline delimited, start with `pie:oob ` followed by a JSON vector of `[type, payload]`. The only current event is `new-vars` whose payload is a simple map of `var-name` to `value`.

Editors can use OOB events to update state locally, without breaking things if the file has been modified, for example.